### PR TITLE
Remove double 'see' entries

### DIFF
--- a/strongsgreek.xml
+++ b/strongsgreek.xml
@@ -599,7 +599,6 @@ and if so, we would appreciate being informed of the error.
  <strongs_derivation>from <strongsref language="GREEK" strongs="1"/> (as a connective particle) and <greek BETA="DELFU/S" unicode="δελφύς" translit="delphýs"/> (the womb);</strongs_derivation><strongs_def> a brother
  (literally or figuratively) near or remote (much like <strongsref language="GREEK" strongs="1"/>)</strongs_def><kjv_def>:--brother.</kjv_def>
 <see language="GREEK" strongs="1"/>
-<see language="GREEK" strongs="1"/>
 </entry><entry strongs="00081">
  <strongs>81</strongs>   <greek BETA="A)DELFO/THS" unicode="ἀδελφότης" translit="adelphótēs"/>   <pronunciation strongs="ad-el-fot'-ace"/>
 
@@ -9278,7 +9277,6 @@ and if so, we would appreciate being informed of the error.
  wish, wot.</kjv_def> Compare <strongsref language="GREEK" strongs="3700"/>.
 <see language="GREEK" strongs="3700"/>
 <see language="GREEK" strongs="3708"/>
-<see language="GREEK" strongs="3700"/>
 </entry><entry strongs="01493">
  <strongs>1493</strongs>   <greek BETA="EI)DWLEI=ON" unicode="εἰδωλεῖον" translit="eidōleîon"/>   <pronunciation strongs="i-do-li'-on"/>
 
@@ -11031,7 +11029,6 @@ and if so, we would appreciate being informed of the error.
  <strongs_derivation>from a (tenth) multiple of <strongsref language="GREEK" strongs="1767"/> and <strongsref language="GREEK" strongs="1767"/> itself;</strongs_derivation><strongs_def> ninety-nine</strongs_def><kjv_def>:--ninety
  and nine.</kjv_def>
 <see language="GREEK" strongs="1767"/>
-<see language="GREEK" strongs="1767"/>
 </entry><entry strongs="01769">
  <strongs>1769</strongs>   <greek BETA="E)NNEO/S" unicode="ἐννεός" translit="enneós"/>   <pronunciation strongs="en-neh-os'"/>
 
@@ -11449,7 +11446,6 @@ and if so, we would appreciate being informed of the error.
  idea of being out in public)</strongs_def><kjv_def>:--be lawful, let,
  X may(-est).</kjv_def>
 <see language="GREEK" strongs="1537"/>
-<see language="GREEK" strongs="1510"/>
 <see language="GREEK" strongs="1510"/>
 </entry><entry strongs="01833">
  <strongs>1833</strongs>   <greek BETA="E)CETA/ZW" unicode="ἐξετάζω" translit="exetázō"/>   <pronunciation strongs="ex-et-ad'-zo"/>
@@ -13079,7 +13075,6 @@ and if so, we would appreciate being informed of the error.
 
  <strongs_derivation>from <strongsref language="GREEK" strongs="2080"/>;</strongs_derivation><strongs_def> from inside; also used as equivalent to <strongsref language="GREEK" strongs="2080"/>
  (inside)</strongs_def><kjv_def>:--inward(-ly), (from) within, without.</kjv_def>
-<see language="GREEK" strongs="2080"/>
 <see language="GREEK" strongs="2080"/>
 </entry><entry strongs="02082">
  <strongs>2082</strongs>   <greek BETA="E)SW/TEROS" unicode="ἐσώτερος" translit="esṓteros"/>   <pronunciation strongs="es-o'-ter-os"/>
@@ -23542,8 +23537,6 @@ and if so, we would appreciate being informed of the error.
  figuratively, be permanent, persevere)</strongs_def><kjv_def>:--abide, continue.</kjv_def>
 <see language="GREEK" strongs="3844"/>
 <see language="GREEK" strongs="3306"/>
-<see language="GREEK" strongs="3306"/>
-<see language="GREEK" strongs="3844"/>
 </entry><entry strongs="03888">
  <strongs>3888</strongs>   <greek BETA="PARAMUQE/OMAI" unicode="παραμυθέομαι" translit="paramythéomai"/>   <pronunciation strongs="par-am-oo-theh'-om-ahee"/>
 
@@ -27405,7 +27398,6 @@ and if so, we would appreciate being informed of the error.
  <strongsref language="GREEK" strongs="3089"/>) or disrupt, lacerate; by implication, to convulse (with spasms);
  figuratively, to give vent to joyful emotions</strongs_def><kjv_def>:--break (forth), burst,
  rend, tear.</kjv_def>
-<see language="GREEK" strongs="2608"/>
 <see language="GREEK" strongs="2608"/>
 <see language="GREEK" strongs="2352"/>
 <see language="GREEK" strongs="3089"/>


### PR DESCRIPTION
I have removed <see language="GREEK" strongs... tags that were duplicates for a given strong's number.